### PR TITLE
fix: add missing <cstdint> include in locale_selector.hpp

### DIFF
--- a/include/wui/locale/locale_selector.hpp
+++ b/include/wui/locale/locale_selector.hpp
@@ -10,6 +10,7 @@
 
 #include <wui/locale/locale_type.hpp>
 #include <vector>
+#include <cstdint>
 
 namespace wui
 {


### PR DESCRIPTION
The header uses int32_t but does not include <cstdint>. This fails to compile with GCC 16 at warning_level=3.