### PR TITLE
fix: add missing <cstdint> include in theme_selector.hpp

### DIFF
--- a/include/wui/theme/theme_selector.hpp
+++ b/include/wui/theme/theme_selector.hpp
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace wui
 {


### PR DESCRIPTION
The header uses int32_t but does not include <cstdint>. This fails to compile with GCC 16 at warning_level=3.