### PR TITLE
fix: propagate size_changed to plains when window is docked

### DIFF
--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -519,6 +519,7 @@ void window::receive_plain_events(const event &ev)
             set_position(new_position);
         }
 
+        send_event_to_plains(ev);
         return;
     }
 


### PR DESCRIPTION
When the window is docked and receives a size_changed event, receive_plain_events() repositions the window but returns early without calling send_event_to_plains(ev). This means draw panels and other plain listeners never receive the resize event, preventing them from relayouting their content.