### PR TITLE
feat: add graphic::draw_image with per-path PNG surface cache

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# 1.3.260902
+1. Add graphic::draw_image: draw a PNG scaled into position with a per-path surface cache (Linux only)
+
 # 1.3.260327
 1. Merged fixes by S.K.
 2. Fix input behavior

--- a/include/wui/graphic/graphic.hpp
+++ b/include/wui/graphic/graphic.hpp
@@ -17,8 +17,10 @@
 
 #include <wui/graphic/primitive_container.hpp>
 
-#include <string_view>
 #include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 
 #ifdef __linux__
 struct _cairo_surface;
@@ -55,6 +57,13 @@ public:
     void draw_rect(rect position, color fill_color);
     void draw_rect(rect position, color border_color, color fill_color, uint32_t border_width, uint32_t round);
 
+    /// Draws a PNG scaled into position. The loaded surface is cached per
+    /// path and owned by this graphic (released on destruction).
+    /// Implemented on Linux only (no-op elsewhere). The cache is not
+    /// invalidated: if the file changes on disk, the previous image is
+    /// reused until the graphic is destroyed.
+    void draw_image(std::string_view file_name, rect position);
+
     /// draw some buffer on context
     void draw_buffer(rect position, uint8_t *buffer, int32_t left_shift, int32_t top_shift);
 
@@ -89,6 +98,7 @@ private:
 
     _cairo_surface *surface;
     _cairo_device *device;
+    std::unordered_map<std::string, _cairo_surface*> image_cache_;
 #endif
 
     error err;

--- a/src/graphic/graphic.cpp
+++ b/src/graphic/graphic.cpp
@@ -166,6 +166,12 @@ void graphic::release()
     DeleteDC(mem_dc);
     mem_dc = 0;
 #elif __linux__
+    for (auto &entry : image_cache_)
+    {
+        if (entry.second) cairo_surface_destroy(entry.second);
+    }
+    image_cache_.clear();
+
     if (surface)
     {
         cairo_surface_destroy(surface);
@@ -537,6 +543,45 @@ void graphic::draw_rect(rect position, color border_color, color fill_color, uin
 
     cairo_destroy(cr);
 
+#endif
+}
+
+void graphic::draw_image(std::string_view file_name, rect position)
+{
+#ifdef __linux__
+    if (!surface || position.is_null() || file_name.empty()) return;
+    const std::string key(file_name);
+    auto it = image_cache_.find(key);
+    if (it == image_cache_.end())
+    {
+        auto *loaded = cairo_image_surface_create_from_png(key.c_str());
+        if (!loaded || cairo_surface_status(loaded) != CAIRO_STATUS_SUCCESS)
+        {
+            if (loaded) cairo_surface_destroy(loaded);
+            return;
+        }
+        it = image_cache_.emplace(key, loaded).first;
+    }
+
+    auto *cr = cairo_create(surface);
+    const int width = cairo_image_surface_get_width(it->second);
+    const int height = cairo_image_surface_get_height(it->second);
+    if (width <= 0 || height <= 0)
+    {
+        cairo_destroy(cr);
+        return;
+    }
+    cairo_save(cr);
+    cairo_translate(cr, position.left, position.top);
+    cairo_scale(cr, static_cast<double>(position.width()) / width,
+                static_cast<double>(position.height()) / height);
+    cairo_set_source_surface(cr, it->second, 0, 0);
+    cairo_paint(cr);
+    cairo_restore(cr);
+    cairo_destroy(cr);
+#else
+    (void)file_name;
+    (void)position;
 #endif
 }
 


### PR DESCRIPTION
Adds `graphic::draw_image(file_name, position)`: draws a PNG scaled into a given rect on the Linux/Cairo backend.

The loaded `cairo_surface_t` is cached per file path in the `graphic`, so repeated draws (e.g. icons painted on every repaint) only pay the decode cost once. The cache is owned by the `graphic` and released in `release()`/the destructor.


## Behavior and limitations

- **Linux only**: the method is a no-op on other platforms (same pattern as the existing `#ifdef` guards). Windows support can follow in a separate change.
- **No cache invalidation**: if the file changes on disk, the previous image is reused until the `graphic` is destroyed. This is intentional for icon-like assets with a bounded set of paths; documented in the header.
- Malformed/missing files fail silently (nothing is drawn), consistent with the defensive style of the other draw calls.