### PR TITLE
feat: periodic timer on the window listener (Linux)

### DIFF
--- a/include/wui/window/listener.h
+++ b/include/wui/window/listener.h
@@ -14,6 +14,8 @@
 #include <wui/system/system_context.hpp>
 #include <wui/common/error.hpp>
 
+#include <chrono>
+#include <functional>
 #include <thread>
 #include <unordered_map>
 
@@ -47,6 +49,15 @@ public:
 
     error const &get_error() const;
 
+    /// Registers a periodic callback invoked on the window event thread
+    /// (listener thread) every `interval`. One timer per process; a new
+    /// interval/callback replaces the previous one.
+    void set_timer(std::chrono::milliseconds interval,
+                   std::function<void()> callback);
+    /// Removes the periodic callback.
+    void clear_timer();
+    bool timer_enabled() const { return timer_enabled_; }
+
 private:
     bool started;
     std::thread thread;
@@ -60,6 +71,13 @@ private:
     void stop();
     
     void process_events();
+
+ private:
+    void dispatch_due_timer();
+    bool timer_enabled_{false};
+    std::chrono::milliseconds timer_interval_{std::chrono::milliseconds(16)};
+    std::chrono::steady_clock::time_point next_tick_{};
+    std::function<void()> on_tick_;
 };
 
 listener& get_listener(); /// Singleton
@@ -76,6 +94,9 @@ public:
     bool init() { return true; }
     system_context const &context() const { static system_context ctx{}; return ctx; }
     error const &get_error() const { static error e{}; return e; }
+    void set_timer(std::chrono::milliseconds, std::function<void()>) {}
+    void clear_timer() {}
+    bool timer_enabled() const { return false; }
 };
 
 inline listener& get_listener() { static listener instance; return instance; }

--- a/src/window/listener.cpp
+++ b/src/window/listener.cpp
@@ -9,6 +9,11 @@
 
 #include <wui/window/listener.h>
 
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <poll.h>
+
 
 namespace wui
 {
@@ -98,48 +103,101 @@ system_context const &listener::context() const
 
 void listener::process_events()
 {
-    xcb_generic_event_t *e = nullptr;
+    const int fd = xcb_get_file_descriptor(context_.connection);
     xcb_flush(context_.connection);
-    while (started && (e = xcb_wait_for_event(context_.connection)))
+    while (started)
     {
-        xcb_window_t w = e->pad[2];
+        const auto now = std::chrono::steady_clock::now();
 
-        switch (e->response_type & ~0x80)
+        // Poll the X connection so the loop stays responsive to both X
+        // events and the periodic timer callback (same listener thread).
+        int timeout_ms = 100;
+        if (timer_enabled_)
         {
-            case XCB_EXPOSE:
-            {
-                auto ev = (xcb_expose_event_t*)e;
-                w = ev->window;
-            }
-            break;
-            case XCB_CONFIGURE_NOTIFY:
-            case XCB_PROPERTY_NOTIFY:
-            case XCB_CLIENT_MESSAGE:
-            {
-                auto ev = (xcb_configure_notify_event_t*)&e;
-                w = e->pad[0];
-            }
-            break;
-            default: break;
+            const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                next_tick_ - now).count();
+            timeout_ms = static_cast<int>(std::clamp<long long>(remaining, 1, 100));
         }
 
-        auto wnd = windows.find(w);
-        if (wnd != windows.end())
+        struct pollfd pfd {};
+        pfd.fd = fd;
+        pfd.events = POLLIN;
+        const int rc = poll(&pfd, 1, timeout_ms);
+
+        if (rc > 0 && (pfd.revents & POLLIN))
         {
-            auto &w = wnd->second;
-            if (!w.created)
+            xcb_generic_event_t *e = nullptr;
+            while ((e = xcb_poll_for_event(context_.connection)))
             {
-                w.created = true;
-                event ev;
-                ev.type = wui::event_type::internal;
-                ev.internal_event_.type = wui::internal_event_type::window_created;
-                w.window_->receive_control_events(ev);
+                xcb_window_t w = e->pad[2];
+
+                switch (e->response_type & ~0x80)
+                {
+                    case XCB_EXPOSE:
+                    {
+                        auto ev = (xcb_expose_event_t*)e;
+                        w = ev->window;
+                    }
+                    break;
+                    case XCB_CONFIGURE_NOTIFY:
+                    case XCB_PROPERTY_NOTIFY:
+                    case XCB_CLIENT_MESSAGE:
+                    {
+                        auto ev = (xcb_configure_notify_event_t*)&e;
+                        w = e->pad[0];
+                    }
+                    break;
+                    default: break;
+                }
+
+                auto wnd = windows.find(w);
+                if (wnd != windows.end())
+                {
+                    auto &w = wnd->second;
+                    if (!w.created)
+                    {
+                        w.created = true;
+                        event ev;
+                        ev.type = wui::event_type::internal;
+                        ev.internal_event_.type = wui::internal_event_type::window_created;
+                        w.window_->receive_control_events(ev);
+                    }
+                    w.window_->process_events(*e);
+                }
+
+                free(e);
             }
-            w.window_->process_events(*e);
         }
 
-        free(e);
+        dispatch_due_timer();
     }
+}
+
+void listener::set_timer(std::chrono::milliseconds interval,
+                         std::function<void()> callback)
+{
+    timer_interval_ = interval > std::chrono::milliseconds(0)
+        ? interval : std::chrono::milliseconds(16);
+    on_tick_ = std::move(callback);
+    next_tick_ = std::chrono::steady_clock::now() + timer_interval_;
+    timer_enabled_ = static_cast<bool>(on_tick_);
+}
+
+void listener::clear_timer()
+{
+    timer_enabled_ = false;
+    on_tick_ = {};
+}
+
+void listener::dispatch_due_timer()
+{
+    if (!timer_enabled_ || !on_tick_) return;
+    const auto now = std::chrono::steady_clock::now();
+    if (now < next_tick_) return;
+    auto callback = on_tick_;
+    callback();
+    const auto next = next_tick_ + timer_interval_;
+    next_tick_ = (next > now) ? next : now + timer_interval_;
 }
 
 error const &listener::get_error() const


### PR DESCRIPTION
Adds a process-wide periodic timer driven by the window event thread: the listener now polls the X connection with a timeout instead of blocking in xcb_wait_for_event and invokes a registered callback every interval on that same thread (set_timer/clear_timer). Windows keeps its existing stub (no-op) and can use the equivalent timer later.

This gives applications a UI-thread tick without extra threads, useful for idle work, throttled refreshes and cross-thread dispatcher draining.