### PR TITLE
feat(listener): thread-safe multi-timer on the window event thread

### DIFF
--- a/include/wui/window/listener.h
+++ b/include/wui/window/listener.h
@@ -63,6 +63,13 @@ public:
     timer_id schedule_timer(std::chrono::milliseconds interval,
                             std::function<void()> callback);
     /// Cancels a timer. Returns false when the id is not registered.
+    ///
+    /// Cancellation is asynchronous with respect to a callback that is already
+    /// running: clear_timer() does not wait for it to finish, so objects
+    /// captured by a running callback (raw pointers/references) must not be
+    /// considered safe to release just because the timer was cancelled. Use
+    /// shared ownership or an explicit lifetime token when the callback may
+    /// outlive the cancellation point.
     bool clear_timer(timer_id id);
     /// Number of active timers (for tests/introspection).
     size_t timer_count() const;

--- a/include/wui/window/listener.h
+++ b/include/wui/window/listener.h
@@ -14,6 +14,10 @@
 #include <wui/system/system_context.hpp>
 #include <wui/common/error.hpp>
 
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <mutex>
 #include <thread>
 #include <unordered_map>
 
@@ -47,8 +51,24 @@ public:
 
     error const &get_error() const;
 
+    /// Opaque and stable across cancellations; 0 == invalid.
+    using timer_id = uint64_t;
+    static constexpr timer_id kInvalidTimer = 0;
+
+    /// Registers a periodic callback invoked on the window event thread
+    /// (listener thread) every `interval`. Several timers can coexist; each
+    /// registration returns a cancellation token. Scheduling is thread-safe:
+    /// the state is guarded by a mutex and an eventfd wakes the listener so a
+    /// short first tick does not wait for the next poll pass.
+    timer_id schedule_timer(std::chrono::milliseconds interval,
+                            std::function<void()> callback);
+    /// Cancels a timer. Returns false when the id is not registered.
+    bool clear_timer(timer_id id);
+    /// Number of active timers (for tests/introspection).
+    size_t timer_count() const;
+
 private:
-    bool started;
+    std::atomic<bool> started{false};
     std::thread thread;
     system_context context_;
 
@@ -58,8 +78,25 @@ private:
 
     void start();
     void stop();
-    
+
     void process_events();
+
+ private:
+    struct Timer
+    {
+        std::chrono::steady_clock::time_point next;
+        std::chrono::milliseconds interval;
+        std::function<void()> callback;
+    };
+
+    bool drain_xcb_events();
+    void dispatch_due_timers();
+    void wake_timer_thread();
+
+    int wakeup_fd_{-1};
+    mutable std::mutex timer_mutex_;
+    std::unordered_map<timer_id, Timer> timers_;
+    timer_id next_timer_id_{kInvalidTimer + 1};
 };
 
 listener& get_listener(); /// Singleton
@@ -69,6 +106,9 @@ listener& get_listener(); /// Singleton
 class listener
 {
 public:
+    using timer_id = uint64_t;
+    static constexpr timer_id kInvalidTimer = 0;
+
     listener() {}
     ~listener() {}
     void add_window(void*, std::shared_ptr<window>) {}
@@ -76,6 +116,14 @@ public:
     bool init() { return true; }
     system_context const &context() const { static system_context ctx{}; return ctx; }
     error const &get_error() const { static error e{}; return e; }
+    /// Listener timers are not supported on this platform: registration
+    /// explicitly returns an invalid token (no silent stubs) so callers can
+    /// degrade knowingly.
+    timer_id schedule_timer(std::chrono::milliseconds, std::function<void()>) {
+        return kInvalidTimer;
+    }
+    bool clear_timer(timer_id) { return false; }
+    size_t timer_count() const { return 0; }
 };
 
 inline listener& get_listener() { static listener instance; return instance; }

--- a/src/window/listener.cpp
+++ b/src/window/listener.cpp
@@ -9,14 +9,23 @@
 
 #include <wui/window/listener.h>
 
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+#include <vector>
+
 
 namespace wui
 {
 
 listener::listener()
-    : started(false),
-    thread{},
-    context_{},
+    : context_{},
     windows{},
     err{}
 {
@@ -47,6 +56,7 @@ void listener::delete_window(xcb_window_t id)
     if (windows.empty())
     {
         started = false;
+        wake_timer_thread();
     }
 }
 
@@ -67,6 +77,11 @@ bool listener::init()
 
     context_.screen = xcb_setup_roots_iterator(xcb_get_setup(context_.connection)).data;
 
+    // Wake-up channel for the listener thread: scheduling/cancelling timers
+    // or stopping writes an event so poll returns immediately instead of
+    // sleeping until its timeout (short ticks are not delayed).
+    wakeup_fd_ = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+
     start();
 
     return true;
@@ -74,21 +89,31 @@ bool listener::init()
 
 void listener::start()
 {
-    if (started)
+    if (started.exchange(true))
     {
         return;
     }
 
-    started = true;
     thread = std::thread(std::bind(&listener::process_events, this));
 }
 
 void listener::stop()
 {
     started = false;
+    wake_timer_thread();
     if (thread.joinable()) thread.join();
 
-    XCloseDisplay(context_.display);
+    if (wakeup_fd_ >= 0)
+    {
+        close(wakeup_fd_);
+        wakeup_fd_ = -1;
+    }
+    if (context_.display)
+    {
+        XCloseDisplay(context_.display);
+        context_.display = nullptr;
+        context_.connection = nullptr;
+    }
 }
 
 system_context const &listener::context() const
@@ -96,12 +121,106 @@ system_context const &listener::context() const
     return context_;
 }
 
+void listener::wake_timer_thread()
+{
+    if (wakeup_fd_ < 0) return;
+    const uint64_t one = 1;
+    (void)write(wakeup_fd_, &one, sizeof(one));  // EAGAIN is fine: the counter is already set
+}
+
 void listener::process_events()
 {
-    xcb_generic_event_t *e = nullptr;
+    const int fd = xcb_get_file_descriptor(context_.connection);
     xcb_flush(context_.connection);
-    while (started && (e = xcb_wait_for_event(context_.connection)))
+
+    while (started)
     {
+        // 1) Due timers (independent; rescheduling from inside the callback
+        //    included - see dispatch_due_timers).
+        dispatch_due_timers();
+
+        // 2) The XCB queue is ALWAYS drained before waiting: events can
+        //    already sit in XCB's internal queue while the socket is empty
+        //    (e.g. after a synchronous wait), so this does not depend on
+        //    POLLIN.
+        if (drain_xcb_events())
+        {
+            continue;  // activity: loop again without blocking
+        }
+
+        // 3) Wait with a timeout until the next timer (or 100 ms idle).
+        int timeout_ms = 100;
+        {
+            std::lock_guard<std::mutex> lock(timer_mutex_);
+            if (!timers_.empty())
+            {
+                auto next = std::chrono::steady_clock::time_point::max();
+                for (const auto& [id, timer] : timers_)
+                    next = std::min(next, timer.next);
+                const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    next - std::chrono::steady_clock::now()).count();
+                timeout_ms = static_cast<int>(std::clamp<long long>(remaining, 1, 1000));
+            }
+        }
+
+        pollfd pfd[2]{};
+        pfd[0].fd = fd;
+        pfd[0].events = POLLIN;
+        nfds_t count = 1;
+        if (wakeup_fd_ >= 0)
+        {
+            pfd[1].fd = wakeup_fd_;
+            pfd[1].events = POLLIN;
+            count = 2;
+        }
+
+        const int rc = poll(pfd, count, timeout_ms);
+        if (rc < 0)
+        {
+            if (errno == EINTR) continue;
+            break;  // error del sistema: salimos
+        }
+
+        if (rc > 0)
+        {
+            // X connection error/close: do not spin in a hot loop; end the
+            // loop just like xcb_wait_for_event returning nullptr did.
+            if (pfd[0].revents & (POLLHUP | POLLERR | POLLNVAL))
+            {
+                started = false;
+                break;
+            }
+
+            // Wake-up consumed (timers rescheduled or stop()).
+            if (count == 2 && (pfd[1].revents & (POLLIN | POLLHUP | POLLERR)))
+            {
+                uint64_t value = 0;
+                while (wakeup_fd_ >= 0 && read(wakeup_fd_, &value, sizeof(value)) > 0)
+                {
+                }
+            }
+
+            if (pfd[0].revents & POLLIN)
+            {
+                drain_xcb_events();
+            }
+        }
+
+        if (xcb_connection_has_error(context_.connection))
+        {
+            started = false;
+            break;
+        }
+    }
+}
+
+bool listener::drain_xcb_events()
+{
+    bool processed = false;
+    xcb_generic_event_t *e = nullptr;
+    while ((e = xcb_poll_for_event(context_.connection)))
+    {
+        processed = true;
         xcb_window_t w = e->pad[2];
 
         switch (e->response_type & ~0x80)
@@ -126,25 +245,96 @@ void listener::process_events()
         auto wnd = windows.find(w);
         if (wnd != windows.end())
         {
-            auto &w = wnd->second;
-            if (!w.created)
+            auto &wnd_data = wnd->second;
+            if (!wnd_data.created)
             {
-                w.created = true;
+                wnd_data.created = true;
                 event ev;
                 ev.type = wui::event_type::internal;
                 ev.internal_event_.type = wui::internal_event_type::window_created;
-                w.window_->receive_control_events(ev);
+                wnd_data.window_->receive_control_events(ev);
             }
-            w.window_->process_events(*e);
+            wnd_data.window_->process_events(*e);
         }
 
         free(e);
     }
+    return processed;
 }
 
-error const &listener::get_error() const
+listener::timer_id listener::schedule_timer(std::chrono::milliseconds interval,
+                                            std::function<void()> callback)
 {
-    return err;
+    if (!callback) return kInvalidTimer;
+
+    const std::chrono::milliseconds safe_interval =
+        interval > std::chrono::milliseconds(0) ? interval : std::chrono::milliseconds(16);
+
+    std::lock_guard<std::mutex> lock(timer_mutex_);
+    timer_id id = next_timer_id_++;
+    if (id == kInvalidTimer) id = next_timer_id_++;  // never return 0
+    timers_[id] = { std::chrono::steady_clock::now() + safe_interval,
+                    safe_interval,
+                    std::move(callback) };
+    wake_timer_thread();
+    return id;
+}
+
+bool listener::clear_timer(timer_id id)
+{
+    bool removed = false;
+    {
+        std::lock_guard<std::mutex> lock(timer_mutex_);
+        removed = timers_.erase(id) > 0;
+    }
+    if (removed) wake_timer_thread();
+    return removed;
+}
+
+size_t listener::timer_count() const
+{
+    std::lock_guard<std::mutex> lock(timer_mutex_);
+    return timers_.size();
+}
+
+void listener::dispatch_due_timers()
+{
+    const auto now = std::chrono::steady_clock::now();
+
+    // Snapshot of due ids under the lock; callbacks run outside the mutex so
+    // schedule_timer/clear_timer may be called from inside a callback without
+    // deadlock (and without racing other threads).
+    std::vector<timer_id> due;
+    {
+        std::lock_guard<std::mutex> lock(timer_mutex_);
+        due.reserve(timers_.size());
+        for (const auto& [id, timer] : timers_)
+            if (timer.next <= now) due.push_back(id);
+    }
+
+    for (timer_id id : due)
+    {
+        std::function<void()> callback;
+        {
+            std::lock_guard<std::mutex> lock(timer_mutex_);
+            auto it = timers_.find(id);
+            if (it == timers_.end() || it->second.next > now) continue;
+            callback = it->second.callback;
+        }
+
+        if (callback) callback();
+
+        // Reschedule relative to the current instant (drift-free and without
+        // the double-interval case of "reconfiguring inside the callback"):
+        // if the callback cancelled this timer it no longer exists and is not
+        // rescheduled; otherwise the next tick is one interval away.
+        std::lock_guard<std::mutex> lock(timer_mutex_);
+        auto it = timers_.find(id);
+        if (it != timers_.end())
+        {
+            it->second.next = std::chrono::steady_clock::now() + it->second.interval;
+        }
+    }
 }
 
 listener& get_listener()

--- a/src/window/listener.cpp
+++ b/src/window/listener.cpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <functional>
 #include <limits>
+#include <optional>
 #include <poll.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
@@ -23,6 +24,14 @@
 
 namespace wui
 {
+
+namespace
+{
+// Events processed per pass: bounds timer latency under a continuous stream
+// of X events (the loop returns and due timers are dispatched between
+// batches).
+constexpr int kMaxEventsPerBatch = 64;
+}
 
 listener::listener()
     : context_{},
@@ -218,9 +227,12 @@ bool listener::drain_xcb_events()
 {
     bool processed = false;
     xcb_generic_event_t *e = nullptr;
-    while ((e = xcb_poll_for_event(context_.connection)))
+    int handled = 0;
+    while (handled < kMaxEventsPerBatch &&
+           (e = xcb_poll_for_event(context_.connection)))
     {
         processed = true;
+        ++handled;
         xcb_window_t w = e->pad[2];
 
         switch (e->response_type & ~0x80)
@@ -282,13 +294,20 @@ listener::timer_id listener::schedule_timer(std::chrono::milliseconds interval,
 
 bool listener::clear_timer(timer_id id)
 {
-    bool removed = false;
+    // The callback is extracted under the lock and destroyed AFTER releasing
+    // it: its destructor may re-enter clear_timer/schedule_timer (e.g. through
+    // a shared_ptr that cancels another timer) and re-acquire the mutex.
+    std::optional<Timer> removed;
     {
         std::lock_guard<std::mutex> lock(timer_mutex_);
-        removed = timers_.erase(id) > 0;
+        auto it = timers_.find(id);
+        if (it == timers_.end()) return false;
+        removed.emplace(std::move(it->second));
+        timers_.erase(it);  // only the already-moved entry is destroyed here
     }
-    if (removed) wake_timer_thread();
-    return removed;
+    removed.reset();        // callback destructor runs without the lock
+    wake_timer_thread();
+    return true;
 }
 
 size_t listener::timer_count() const
@@ -335,6 +354,11 @@ void listener::dispatch_due_timers()
             it->second.next = std::chrono::steady_clock::now() + it->second.interval;
         }
     }
+}
+
+error const &listener::get_error() const
+{
+    return err;
 }
 
 listener& get_listener()


### PR DESCRIPTION
Replaces the single global timer with registrable periodic timers that run on the window event thread (`schedule_timer`/`clear_timer` with cancellation tokens).
>
> - **P1 – XCB queue**: events already queued internally are drained before every blocking `poll`, independent of `POLLIN`.
> - **P1 – data race**: timer state is guarded by a mutex; an eventfd wakes the poll immediately on schedule/cancel, and callbacks run outside the lock so a timer can reschedule/cancel itself safely.
> - **P2 – connection loss**: `POLLHUP/POLLERR/POLLNVAL` and XCB connection errors end the loop cleanly (no busy spin).
> - **P2 – reschedule from callback**: the next tick is scheduled relative to the current time after the callback — no double interval.
> - **API**: multiple independent timers instead of one silently-overwritten global; unsupported platforms return an invalid token (no silent stub).
